### PR TITLE
Minor change to timestamps

### DIFF
--- a/Resources/app/modules/ui.js
+++ b/Resources/app/modules/ui.js
@@ -45,7 +45,7 @@ define([
         var diff = date_diff(in_date, new Date());
 
         if (diff < 30) return 'A few seconds ago';
-        if (diff < 60) return 'About a minute ago';
+        if (diff < 120) return 'About a minute ago';
         if (diff < 300) return Math.floor(diff / 60) + ' minutes ago';
         if (diff < 3600 * 5) return time;
         return filedate_str;


### PR DESCRIPTION
The compilation timestamp previously displayed "1 minutes ago" from 60 to 119 seconds after compilation. Extend the display of the existing timestamp "About a minute ago" all the way to second 119, when the message becomes "2 minutes ago" like normal.
