### PR TITLE
Fixed version formatting

### DIFF
--- a/nwData/package.json
+++ b/nwData/package.json
@@ -2,7 +2,7 @@
     "name": "SimpLESS",
     "main": "index.html",
     "description": "A simple app to compile your LESS files into CSS.",
-    "version": "2.0",
+    "version": "2.0.0",
     "keywords": ["less", "css", "compiler"],
 
     "update": {


### PR DESCRIPTION
npm requires 3-decimal formatting of the version number (x.x.x) as opposed to 2-decimal (x.x).

Attempting to install SimpLESS failed when installing LESS and socket.io to the nwData directory with the error:

```
npm ERR! Error: invalid version: 2.0
npm ERR!     at validVersion (/usr/lib/nodejs/read-package-json/read-json.js:573:40)
npm ERR!     at final (/usr/lib/nodejs/read-package-json/read-json.js:323:23)
npm ERR!     at /usr/lib/nodejs/read-package-json/read-json.js:139:33
npm ERR!     at cb (/usr/lib/nodejs/slide/lib/async-map.js:48:11)
npm ERR!     at /usr/lib/nodejs/read-package-json/read-json.js:301:48
npm ERR!     at fs.js:207:20
npm ERR!     at OpenReq.Req.done (/usr/lib/nodejs/graceful-fs/graceful-fs.js:135:5)
npm ERR!     at OpenReq.done (/usr/lib/nodejs/graceful-fs/graceful-fs.js:64:22)
npm ERR!     at Object.oncomplete (fs.js:107:15)
npm ERR! If you need help, you may report this log at:
npm ERR!     <http://bugs.debian.org/npm>
npm ERR! or use
npm ERR!     reportbug --attach /media/damon/Storage/Library/Downloads/simpless/SimpLESS/nwData/npm-debug.log npm
```

Changing the version number to a 3-decimal format fixes this.
